### PR TITLE
Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,49 +15,53 @@ environment:
       NUMPY_HEAD: https://github.com/xoviat/numpy.git
       NUMPY_BRANCH: distutils
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
-      PYPI_USERNAME:
-          secure: rl2zkdPpMWKuqh3paOKNhA==
-      PYPI_PASSWORD:
-          secure: rToy5D17/4zLIaIBq9S4UQ==
+      APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
       TEST_TIMEOUT: 600
 
   matrix:
-# Assume the older versions are more likely to fail
     - PYTHON: C:\Python27-x64
       PYTHON_VERSION: 2.7
       PYTHON_ARCH: 64
+      TEST_MODE: fast
+
+    - PYTHON: C:\Python34-x64
+      PYTHON_VERSION: 3.4
+      PYTHON_ARCH: 64
+      TEST_MODE: fast
+
+    - PYTHON: C:\Python36-x64
+      PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 64
+      TEST_MODE: full
+
+    - PYTHON: C:\Python36
+      PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 32
+      TEST_MODE: fast
 
     - PYTHON: C:\Python27
       PYTHON_VERSION: 2.7
       PYTHON_ARCH: 32
       SKIP_NOTAG: true
-
-    - PYTHON: C:\Python34-x64
-      PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 64
+      TEST_MODE: full
 
     - PYTHON: C:\Python34
       PYTHON_VERSION: 3.4
       PYTHON_ARCH: 32
       SKIP_NOTAG: true
+      TEST_MODE: full
 
     - PYTHON: C:\Python35-x64
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 64
       SKIP_NOTAG: true
+      TEST_MODE: full
 
     - PYTHON: C:\Python35
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 32
       SKIP_NOTAG: true
-
-    - PYTHON: C:\Python36-x64
-      PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 64
-    
-    - PYTHON: C:\Python36
-      PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 32
+      TEST_MODE: full
 
 
 matrix:
@@ -65,7 +69,6 @@ matrix:
     # TMP allow failures until tests are fixed (remove PYTHON_ARCH to reverse)  
     - PYTHON_ARCH: 32
     # - PYTHON_ARCH: 64
-    - SKIP_NOTAG: true
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -78,10 +81,13 @@ init:
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-          throw "There are newer queued builds for this pull request, failing early." }
+          Write-Host "There are newer queued builds for this pull request, skipping build."
+          Exit-AppveyorBuild
+        }
   - ps: |
       If (($env:SKIP_NOTAG -eq "true") -and ($env:APPVEYOR_REPO_TAG -ne "true")) {
-          throw "Skipping Python version, not a tag."
+          Write-Host "Skipping build, not at a tag."
+          Exit-AppveyorBuild
       }
 
 cache:
@@ -144,19 +150,13 @@ install:
       
       cd "$CurrentDir"
 
-  - ps: |
-      cd scipy\integrate\odepack
-      rm xsetf.f
-      rm xsetun.f
-      cd ..\..\..
-
-
   # Upgrade to the latest pip.
   - '%CMD_IN_ENV% python -m pip install -U pip setuptools wheel'
 
   # Install the PyInstaller test dependencies.
   - '%CMD_IN_ENV% pip install -U --timeout 5 --retries 2 -r tools/ci/appveyor/requirements.txt'
 
+  # Replace numpy distutils with a version that can build with msvc + mingw-gfortran
   - ps: |
       $CurrentDir = $(get-location).Path;
       $NumpyDir = (python -c 'import os; import numpy; print(os.path.dirname(numpy.__file__))') | Out-String
@@ -180,6 +180,7 @@ build_script:
           $env:MINGW = $env:MINGW_64
       }
       $env:Path += ";$env:MINGW"
+      $env:NPY_NUM_BUILD_JOBS = "4"
       mkdir dist
       pip wheel -v -v -v --wheel-dir=dist .
 
@@ -189,22 +190,7 @@ build_script:
       }
 
 test_script:
-  - ps: |
-      $CurrentDir = $(get-location).Path;
-      $ScipyDir = (python -c 'import os; import sys; sys.path.remove(""""); import scipy; print(os.path.dirname(scipy.__file__))') | Out-String
-      $ScipyDir = $ScipyDir.Trim()
-      rm -r -Force scipy
-      cmd /c mklink /J scipy $ScipyDir
-
-  - py.test scipy -n6 --timeout=%TEST_TIMEOUT% --junitxml=junit-results.xml
-
-on_success:
-  - ps: |
-      If ($env:APPVEYOR_REPO_TAG -eq "true") {
-          pip install twine
-          Invoke-Expression "twine upload -u $env:PYPI_USERNAME -p $env:PYPI_PASSWORD --repository-url https://upload.pypi.org/legacy/ --skip-existing dist/*" 2>&1 | Out-Null
-      }
-
+  - python runtests.py -n -m %TEST_MODE% -- -n6 --timeout=%TEST_TIMEOUT% --junitxml=%cd%\junit-results.xml -rfEX
 
 after_build:
   # Remove old or huge cache files to hopefully not exceed the 1GB cache limit.
@@ -229,8 +215,10 @@ after_build:
 
 on_finish:
   - ps: |
-      (new-object net.webclient).UploadFile(
-        "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)",
-        (Resolve-Path .\junit-results.xml)
-      )
+      If (Test-Path .\junit-results.xml) {
+        (new-object net.webclient).UploadFile(
+          "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)",
+          (Resolve-Path .\junit-results.xml)
+        )
+      }
       $LastExitCode = 0

--- a/scipy/special/cephes/ellik.c
+++ b/scipy/special/cephes/ellik.c
@@ -58,12 +58,7 @@
 #include "mconf.h"
 extern double MACHEP;
 
-#if defined(_MSC_VER) && _MSC_VER <= 1600
-double asinh(double x)
-{
-    return log(x + sqrt(x * x + 1));
-}
-#endif
+#include <numpy/npy_math.h>
 
 static double ellik_neg_m(double phi, double m);
 
@@ -94,7 +89,7 @@ double ellik(double phi,  double m)
 	    return (NPY_INFINITY);
 	}
         /* DLMF 19.6.8, and 4.23.42 */
-       return asinh(tan(phi));
+       return npy_asinh(tan(phi));
     }
     npio2 = floor(phi / NPY_PI_2);
     if (fmod(fabs(npio2), 2.0) == 1.0)

--- a/tools/ci/appveyor/requirements.txt
+++ b/tools/ci/appveyor/requirements.txt
@@ -4,3 +4,7 @@ nose
 pytest-timeout
 pytest-xdist
 pytest-env
+pytest-faulthandler
+Pillow
+mpmath
+matplotlib


### PR DESCRIPTION
Additional changes for https://github.com/scipy/scipy/pull/7616

Appveyor: https://ci.appveyor.com/project/pv/scipy-travis/build/1.0.10 (including some extra bugfixes for spurious test failures, which are currently in separate PRs.)

```
commit 64e66ab224d5084ca8ac0c6b3421681ec5c01f13 (HEAD -> pr-7616-2, github/pr-7616)
Author: Pauli Virtanen <pav@iki.fi>
Date:   Mon Aug 7 15:28:36 2017 +0200

    Use npy_asinh in place of asinh for MSVC compatibility

commit 0dfa51a9c8c287f3bba78501d05557287fb37155
Author: Pauli Virtanen <pav@iki.fi>
Date:   Sat Aug 5 15:02:33 2017 +0200

    CI: appveyor: update config
    
    - Drop unused pypi upload from appveyor
      The releases are signed and won't be uploaded directly to Pypi.
      If we want to add this later on, it's simple to add.
    - Don't try to upload non-existing test results
    - Remove unneeded xsetf/xsetun patching
    - Move tag builds to the end of the matrix
    - Add test modes and simplify pytest call
    - Install additional test dependencies
    - Enable parallel builds
    - Add pytest summary flags
    - Use a better way to skip builds, reporting success.
```